### PR TITLE
Custom Items - The Flagbearer | Fixes for Arachno-Man mask and costume

### DIFF
--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -236,5 +236,25 @@
 	icon_state = "noble_boot"
 	_color = "noble_boot"
 	item_state = "noble_boot"
+	
+/////Arachno-Man Costume set //the flagbearer: Willow Walker
+/obj/item/clothing/under/fluff/arachno_suit // Custom Jumpsuit
+	name = "Arachno-Man costume"
+	desc = "It's what an evil genius would design if he switched brains with the Amazing Arachno-Man. Actually, he'd probably add weird tentacles that come out the back, too."
+	icon = 'icons/obj/uniforms.dmi'
+	icon_state = "superior_suit"
+	item_state = "superior_suit"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	flags_inv = HIDEGLOVES|HIDESHOES
+	
+/obj/item/clothing/head/fluff/arachno_mask
+	name = "Arachno-Man mask"
+	desc = "Put it on. The mask, it's gonna make you stronger!"
+	icon = 'icons/obj/custom_items.dmi'
+	icon_state = "superior_mask"
+	item_state = "superior_mask"
+	body_parts_covered = HEAD
+	flags_inv = HIDEFACE
+	flags = BLOCKHAIR
 
 //////////// Weapons ////////////


### PR DESCRIPTION
This patch fixes the mask sprite for the Arachno-Man mask and fixes the file path for the costume which doesn't appear when worn.

What it looks like currently:
![image](https://cloud.githubusercontent.com/assets/12586362/7803592/1a9f9ad6-0322-11e5-9473-2d1732c47dd9.png)

Do not merge yet, as the patch is incomplete.
